### PR TITLE
fix flickering tabs

### DIFF
--- a/src/gitbook-azure.css
+++ b/src/gitbook-azure.css
@@ -1769,7 +1769,7 @@ button.active,
 
 .window-header button,
 #close-sidebar-menu-btn,
-.html-for-mac .sidebar-tab-btn,
+/* .html-for-mac .sidebar-tab-btn, */
 .label-hint,
 .ty-table-edit .btn,
 .zoom-hint-button,
@@ -1781,6 +1781,13 @@ button.active,
     background-color: transparent !important;
     color: var(--light-text-color) !important;
     opacity: 1 !important;
+    transition-duration: 0.2s;
+    transition-property: color;
+}
+
+.html-for-mac .sidebar-tab-btn {
+    background-color: transparent !important;
+    color: var(--light-text-color) !important;
     transition-duration: 0.2s;
     transition-property: color;
 }

--- a/src/gitbook-slate.css
+++ b/src/gitbook-slate.css
@@ -1711,7 +1711,7 @@ button.active,
 
 .window-header button,
 #close-sidebar-menu-btn,
-.html-for-mac .sidebar-tab-btn,
+/* .html-for-mac .sidebar-tab-btn, */
 .label-hint,
 .ty-table-edit .btn,
 .zoom-hint-button,
@@ -1723,6 +1723,13 @@ button.active,
     background-color: transparent !important;
     color: var(--light-text-color) !important;
     opacity: 1 !important;
+    transition-duration: 0.2s;
+    transition-property: color;
+}
+
+.html-for-mac .sidebar-tab-btn {
+    background-color: transparent !important;
+    color: var(--light-text-color) !important;
     transition-duration: 0.2s;
     transition-property: color;
 }

--- a/src/gitbook-teal.css
+++ b/src/gitbook-teal.css
@@ -1767,7 +1767,7 @@ button.active,
 
 .window-header button,
 #close-sidebar-menu-btn,
-.html-for-mac .sidebar-tab-btn,
+/* .html-for-mac .sidebar-tab-btn, */
 .label-hint,
 .ty-table-edit .btn,
 .zoom-hint-button,
@@ -1779,6 +1779,13 @@ button.active,
     background-color: transparent !important;
     color: var(--light-text-color) !important;
     opacity: 1 !important;
+    transition-duration: 0.2s;
+    transition-property: color;
+}
+
+.html-for-mac .sidebar-tab-btn {
+    background-color: transparent !important;
+    color: var(--light-text-color) !important;
     transition-duration: 0.2s;
     transition-property: color;
 }


### PR DESCRIPTION
@h16nning the hamburger menu icon and magnifying glass icon flicker, when the mouse cursor moves into the sidebar

this pr essentially resets their opacity to 0 when the mouse cursor isn't inside the sidebar
opacity 0 seems to be default behavior anyway